### PR TITLE
Sort parameters in dependency computations

### DIFF
--- a/libvvtest/parsevvt.py
+++ b/libvvtest/parsevvt.py
@@ -857,8 +857,8 @@ def to_str( obj ):
 def test_id_tuple( testname, test_params ):
     ""
     L = [testname]
-    for k,v in test_params.items():
-        L.append( (k,to_str(v)) )
+    for k in sorted(test_params):
+        L.append( (k,to_str(test_params[k])) )
     return tuple(L)
 
 


### PR DESCRIPTION
I ran into an issue where dependencies were skipped because they were not found in `depmap`. The reason was that the ordering of parameters returned by `test_id_tuple` was different on subsequent calls. Unfortunately, I was not able to reproduce this in a test.